### PR TITLE
fix -h output

### DIFF
--- a/run_al.py
+++ b/run_al.py
@@ -681,11 +681,11 @@ if __name__ == '__main__':
     parser.add_argument("--acquisition_size", required=False,
                         default=None,
                         type=int,
-                        help="acquisition size at each AL iteration; if None we sample 1%")
+                        help="acquisition size at each AL iteration; if None we sample 1%%")
     parser.add_argument("--init_train_data", required=False,
                         default=None,
                         type=int,
-                        help="initial training data for AL; if None we sample 1%")
+                        help="initial training data for AL; if None we sample 1%%")
     parser.add_argument("--indicator", required=False,
                         default=None,
                         type=str,


### PR DESCRIPTION
unescaped '%' made -h throw "ValueError: incomplete format"