### PR TITLE
remove fixed budget

### DIFF
--- a/run_al.py
+++ b/run_al.py
@@ -88,7 +88,6 @@ def al_loop(args):
 
     args.acquisition_size = round(len(X_train_original_inds) * 2 / 100)  # 2%
     args.init_train_data = round(len(X_train_original_inds) * 1 / 100)  # 1%
-    args.budget = round(len(X_train_original_inds) * 17 / 100)  # 25%
 
     tokenizer = AutoTokenizer.from_pretrained(
         args.tokenizer_name if args.tokenizer_name else args.model_name_or_path,


### PR DESCRIPTION
The budget was fixed at 17% (with a comment of 25%) of X_train_original_inds
The deleted line would overwrite the budget, always to be 425 ( l#66 caps the length of X_train_original_inds at 2500 )
I'm not sure why this was done, but it seems like an artefact, please correct me if I'm wrong! :)